### PR TITLE
将 v3.0.2 发布提交归并主线

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,7 +4969,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibehub"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "vibehub-cli"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "vibehub-core"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/vibehub-cli/Cargo.toml
+++ b/crates/vibehub-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibehub-cli"
-version = "3.0.1"
+version = "3.0.2"
 description = "Command line interface for VibeHub Core"
 authors = ["VibeHub"]
 license = "Apache-2.0"

--- a/crates/vibehub-core/Cargo.toml
+++ b/crates/vibehub-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibehub-core"
-version = "3.0.1"
+version = "3.0.2"
 description = "Core VibeHub workflow engine"
 authors = ["VibeHub"]
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vibehub",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vibehub",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vibehub",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "A cross-platform launcher for development tools",
     "license": "Apache-2.0",
     "type": "module",

--- a/scripts/release/preflight.mjs
+++ b/scripts/release/preflight.mjs
@@ -7,6 +7,7 @@ const readJson = async (path) => JSON.parse(await readText(path));
 const packageJson = await readJson("package.json");
 const packageLock = await readJson("package-lock.json");
 const tauriConfig = await readJson("src-tauri/tauri.conf.json");
+const tauriWindowsConfig = await readJson("src-tauri/tauri.windows.conf.json");
 const coreCargo = await readText("crates/vibehub-core/Cargo.toml");
 const cliCargo = await readText("crates/vibehub-cli/Cargo.toml");
 const tauriCargo = await readText("src-tauri/Cargo.toml");
@@ -31,6 +32,32 @@ const versions = new Map([
 for (const [label, version] of versions) {
   if (version !== expected) {
     throw new Error(`version mismatch: ${label}=${version ?? "<missing>"}, expected ${expected}`);
+  }
+}
+
+const baseWindow = tauriConfig.app?.windows?.[0];
+const windowsWindow = tauriWindowsConfig.app?.windows?.[0];
+if (baseWindow?.decorations !== true) {
+  throw new Error("base Tauri window must retain native decorations for non-Windows platforms");
+}
+if (windowsWindow?.decorations !== false) {
+  throw new Error("Windows Tauri window must disable native decorations for the custom title bar");
+}
+
+const sharedWindowFields = [
+  "title",
+  "width",
+  "height",
+  "minWidth",
+  "minHeight",
+  "resizable",
+  "fullscreen",
+  "transparent",
+  "center",
+];
+for (const field of sharedWindowFields) {
+  if (windowsWindow[field] !== baseWindow[field]) {
+    throw new Error(`Windows Tauri window ${field} must match the base window configuration`);
   }
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibehub"
-version = "3.0.1"
+version = "3.0.2"
 description = "A cross-platform launcher for development tools"
 authors = ["VibeHub"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema":  "https://schema.tauri.app/config/2.0",
     "productName":  "VibeHub",
-    "version":  "3.0.1",
+    "version":  "3.0.2",
     "identifier":  "com.vibehub.launcher",
     "build":  {
                   "beforeDevCommand":  "npm run dev",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schema.tauri.app/config/2.0",
+    "app": {
+        "windows": [
+            {
+                "title": "VibeHub",
+                "width": 1200,
+                "height": 800,
+                "minWidth": 900,
+                "minHeight": 600,
+                "resizable": true,
+                "fullscreen": false,
+                "decorations": false,
+                "transparent": false,
+                "center": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## 目的

将已经发布并打上 `v3.0.2` tag 的 Windows 自定义标题栏修复归并回 `main`，结束长期 release 分支造成的双主线状态。

## 变更

- Windows 使用独立 Tauri 配置关闭系统原生标题栏
- 发布前检查验证 Windows 配置覆盖边界
- 项目版本统一为 3.0.2

## 分支收口

合并后删除 `release/v3.0.0` 与 `feature/vibehub-v2-p0`；版本 tags 和 Releases 保留不变。

## 验证边界

Release workflow 已成功；Windows 原生视觉验收仍按 V3 blocker 保持待 Windows 主机确认，不由 CI 代替。