### PR TITLE
fix(v3): protect legacy task compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,7 +4969,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibehub"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "vibehub-cli"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "vibehub-core"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/vibehub-cli/Cargo.toml
+++ b/crates/vibehub-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibehub-cli"
-version = "3.0.2"
+version = "3.0.3"
 description = "Command line interface for VibeHub Core"
 authors = ["VibeHub"]
 license = "Apache-2.0"

--- a/crates/vibehub-cli/src/dispatcher.rs
+++ b/crates/vibehub-cli/src/dispatcher.rs
@@ -120,6 +120,7 @@ vibehub-cli <action> <project_path> [args...]   (legacy alias)
   v3 <project> repair-candidates
   v3 <project> repair <task_id>
   v3 <project> task-create <request_json_path|--stdin|->
+  v3 <project> quarantine-task <task_id>
   v3 <project> agent-specs-status
   v3 <project> agent-specs-sync [--force-managed-region]
   v3 <project> session-open <project_id> <task_id> <session_id> <actor> <expected_version> <idempotency_key> [working_directory] [node_id|-] [worktree_id|-] [provider] [provider_session_id|-]
@@ -493,6 +494,13 @@ fn run_v3_action(project_root: &str, args: &[String]) {
                     std::process::exit(2);
                 });
             print_v3_json(vibehub_core::v3::create_v3_task(project_root, request));
+            return;
+        }
+        "quarantine-task" => {
+            let Some(task_id) = args.get(1) else {
+                v3_usage_error(command, "missing task_id");
+            };
+            print_v3_json(vibehub_core::v3::quarantine_v3_task(project_root, task_id));
             return;
         }
         "agent-specs-status" => {

--- a/crates/vibehub-core/Cargo.toml
+++ b/crates/vibehub-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibehub-core"
-version = "3.0.2"
+version = "3.0.3"
 description = "Core VibeHub workflow engine"
 authors = ["VibeHub"]
 license = "Apache-2.0"

--- a/crates/vibehub-core/src/v3/mod.rs
+++ b/crates/vibehub-core/src/v3/mod.rs
@@ -10,6 +10,7 @@ pub mod project_intelligence;
 pub mod project_settings;
 pub mod projection;
 pub mod task_creation;
+pub mod task_quarantine;
 pub mod views;
 pub mod worktree;
 
@@ -30,5 +31,6 @@ pub use orchestration::{
 pub use project_intelligence::{ProjectIndexService, ProjectModelSnapshot, ProjectPage};
 pub use project_settings::*;
 pub use task_creation::{create_v3_task, V3TaskCreateRequest, V3TaskCreateResult};
+pub use task_quarantine::{quarantine_v3_task, V3TaskQuarantineResult};
 pub use views::{V3ViewBundle, V3ViewRepository};
 pub use worktree::*;

--- a/crates/vibehub-core/src/v3/task_quarantine.rs
+++ b/crates/vibehub-core/src/v3/task_quarantine.rs
@@ -1,0 +1,356 @@
+use super::{inspect_project_layout, ProjectLayoutState, V3Error, V3ErrorCategory};
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+const MAX_TASK_METADATA_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct V3TaskQuarantineResult {
+    pub status: String,
+    pub task_id: String,
+    pub source_path: String,
+    pub archive_path: String,
+    pub audit_path: String,
+}
+
+#[derive(Debug, Serialize)]
+struct QuarantineAudit<'a> {
+    schema_version: u32,
+    kind: &'a str,
+    task_id: &'a str,
+    source_path: String,
+    archive_path: String,
+    quarantined_at: String,
+    reason_code: &'a str,
+    reason: &'a str,
+    action: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct V3TaskMetadata {
+    task_id: String,
+    title: String,
+    intent: String,
+    phase: String,
+    phase_status: String,
+    #[serde(default)]
+    acceptance_criteria: Vec<String>,
+    #[serde(default)]
+    dependencies: Vec<String>,
+}
+
+struct TaskMetadataIssue {
+    code: &'static str,
+    message: String,
+}
+
+/// Moves an invalid task directory out of `.vibehub/tasks` without deleting
+/// its artifacts. The task directory and audit record are finalized by one
+/// directory rename inside `.vibehub/quarantine/tasks`.
+pub fn quarantine_v3_task(
+    project_root: impl AsRef<Path>,
+    task_id: &str,
+) -> Result<V3TaskQuarantineResult, V3Error> {
+    let project_root = project_root
+        .as_ref()
+        .canonicalize()
+        .map_err(|error| io_error("V3_TASK_QUARANTINE_PROJECT_NOT_FOUND", error))?;
+    if inspect_project_layout(&project_root)?.state != ProjectLayoutState::V3 {
+        return Err(validation(
+            "V3_TASK_QUARANTINE_REQUIRES_V3",
+            "task quarantine is only available in a schema_version: 3 project",
+        ));
+    }
+    validate_task_id(task_id)?;
+
+    let root = project_root.join(".vibehub");
+    let source = root.join("tasks").join(task_id);
+    require_regular_directory(&source, "V3_TASK_QUARANTINE_TASK_NOT_FOUND")?;
+    let issue = task_metadata_issue(&source.join("task.yaml"), task_id)?;
+    let Some(issue) = issue else {
+        return Err(validation(
+            "V3_TASK_QUARANTINE_REQUIRES_INVALID_METADATA",
+            "refusing to quarantine a task whose V3 metadata is valid",
+        ));
+    };
+
+    let quarantine_root = ensure_quarantine_root(&root)?;
+    let archive_name = format!("{}-{}", task_id, Uuid::new_v4().simple());
+    let staging = quarantine_root.join(format!(".staging-{archive_name}"));
+    let archive = quarantine_root.join(&archive_name);
+    fs::create_dir(&staging)
+        .map_err(|error| io_error("V3_TASK_QUARANTINE_STAGE_CREATE_FAILED", error))?;
+
+    let source_path = project_relative(&project_root, &source);
+    let archive_path = project_relative(&project_root, &archive.join("task"));
+    let audit_path = project_relative(&project_root, &archive.join("audit.json"));
+    let audit = QuarantineAudit {
+        schema_version: 1,
+        kind: "v3_task_quarantine",
+        task_id,
+        source_path: source_path.clone(),
+        archive_path: archive_path.clone(),
+        quarantined_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+        reason_code: issue.code,
+        reason: &issue.message,
+        action: "quarantined",
+    };
+    let audit_content = serde_json::to_vec_pretty(&audit)
+        .map_err(|error| validation("V3_TASK_QUARANTINE_AUDIT_ENCODE_FAILED", error.to_string()))?;
+    if let Err(error) = write_new_synced(
+        &staging.join("audit.json"),
+        &audit_content,
+        "V3_TASK_QUARANTINE_AUDIT_WRITE_FAILED",
+    ) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+    if let Err(error) = fs::rename(&source, staging.join("task")) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(io_error("V3_TASK_QUARANTINE_MOVE_FAILED", error));
+    }
+    if let Err(error) = fs::rename(&staging, &archive) {
+        return Err(io_error("V3_TASK_QUARANTINE_FINALIZE_FAILED", error)
+            .with_detail("recovery_path", project_relative(&project_root, &staging)));
+    }
+
+    Ok(V3TaskQuarantineResult {
+        status: "quarantined".to_owned(),
+        task_id: task_id.to_owned(),
+        source_path,
+        archive_path,
+        audit_path,
+    })
+}
+
+fn task_metadata_issue(
+    task_yaml: &Path,
+    expected_task_id: &str,
+) -> Result<Option<TaskMetadataIssue>, V3Error> {
+    let metadata = match fs::symlink_metadata(task_yaml) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Some(TaskMetadataIssue {
+                code: "V3_TASK_METADATA_INVALID",
+                message: "task.yaml is missing".to_owned(),
+            }));
+        }
+        Err(error) => return Err(io_error("V3_TASK_QUARANTINE_TASK_READ_FAILED", error)),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Ok(Some(TaskMetadataIssue {
+            code: "V3_TASK_METADATA_INVALID",
+            message: "task.yaml must be a regular file".to_owned(),
+        }));
+    }
+    if metadata.len() > MAX_TASK_METADATA_BYTES {
+        return Ok(Some(TaskMetadataIssue {
+            code: "V3_TASK_METADATA_INVALID",
+            message: format!("task.yaml exceeds {MAX_TASK_METADATA_BYTES} bytes"),
+        }));
+    }
+    let content = fs::read_to_string(task_yaml)
+        .map_err(|error| io_error("V3_TASK_QUARANTINE_TASK_READ_FAILED", error))?;
+    let task: V3TaskMetadata = match serde_yaml::from_str(&content) {
+        Ok(task) => task,
+        Err(error) => {
+            return Ok(Some(TaskMetadataIssue {
+                code: "V3_TASK_METADATA_INVALID",
+                message: limited_message(error.to_string()),
+            }));
+        }
+    };
+    if task.task_id != expected_task_id {
+        return Ok(Some(TaskMetadataIssue {
+            code: "V3_TASK_METADATA_INVALID",
+            message: "task.yaml task_id does not match its task directory".to_owned(),
+        }));
+    }
+    if [
+        task.title.as_str(),
+        task.intent.as_str(),
+        task.phase.as_str(),
+        task.phase_status.as_str(),
+    ]
+    .iter()
+    .any(|field| field.trim().is_empty())
+    {
+        return Ok(Some(TaskMetadataIssue {
+            code: "V3_TASK_METADATA_INVALID",
+            message: "a required V3 task metadata field is empty".to_owned(),
+        }));
+    }
+    let _ = (task.acceptance_criteria, task.dependencies);
+    Ok(None)
+}
+
+fn ensure_quarantine_root(root: &Path) -> Result<PathBuf, V3Error> {
+    require_regular_directory(root, "V3_TASK_QUARANTINE_ROOT_INVALID")?;
+    let quarantine = root.join("quarantine");
+    ensure_regular_directory(&quarantine, "V3_TASK_QUARANTINE_ROOT_INVALID")?;
+    let tasks = quarantine.join("tasks");
+    ensure_regular_directory(&tasks, "V3_TASK_QUARANTINE_ROOT_INVALID")?;
+    Ok(tasks)
+}
+
+fn require_regular_directory(path: &Path, code: &'static str) -> Result<(), V3Error> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => Ok(()),
+        Ok(_) => Err(validation(code, "path must be a regular directory")),
+        Err(error) => Err(io_error(code, error)),
+    }
+}
+
+fn ensure_regular_directory(path: &Path, code: &'static str) -> Result<(), V3Error> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => Ok(()),
+        Ok(_) => Err(validation(code, "path must be a regular directory")),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir(path).map_err(|error| io_error(code, error))
+        }
+        Err(error) => Err(io_error(code, error)),
+    }
+}
+
+fn write_new_synced(path: &Path, content: &[u8], code: &'static str) -> Result<(), V3Error> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| io_error(code, error))?;
+    file.write_all(content)
+        .and_then(|_| file.write_all(b"\n"))
+        .and_then(|_| file.sync_all())
+        .map_err(|error| io_error(code, error))
+}
+
+fn project_relative(project_root: &Path, path: &Path) -> String {
+    path.strip_prefix(project_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn validate_task_id(task_id: &str) -> Result<(), V3Error> {
+    if task_id.is_empty()
+        || task_id.len() > 128
+        || task_id.contains("..")
+        || !task_id.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
+        })
+    {
+        return Err(validation(
+            "V3_TASK_QUARANTINE_TASK_ID_INVALID",
+            "task identifier is unsafe",
+        ));
+    }
+    Ok(())
+}
+
+fn limited_message(message: String) -> String {
+    const MAX_CHARS: usize = 512;
+    if message.chars().count() <= MAX_CHARS {
+        message
+    } else {
+        format!("{}…", message.chars().take(MAX_CHARS).collect::<String>())
+    }
+}
+
+fn validation(code: &str, message: impl Into<String>) -> V3Error {
+    V3Error::new(code, V3ErrorCategory::Validation, false, message)
+}
+
+fn io_error(code: &'static str, error: std::io::Error) -> V3Error {
+    let category = if error.kind() == std::io::ErrorKind::NotFound {
+        V3ErrorCategory::NotFound
+    } else {
+        V3ErrorCategory::Internal
+    };
+    V3Error::new(code, category, false, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v3::{create_v3_task, initialize_v3, V3TaskCreateRequest, V3ViewRepository};
+    use serde_json::Value;
+
+    fn temp_project() -> PathBuf {
+        let project =
+            std::env::temp_dir().join(format!("vibehub-v3-quarantine-{}", Uuid::new_v4()));
+        fs::create_dir(&project).unwrap();
+        project
+    }
+
+    #[test]
+    fn quarantines_invalid_task_without_deleting_artifacts_and_restores_views() {
+        let project = temp_project();
+        initialize_v3(&project).unwrap();
+        let valid = create_v3_task(
+            &project,
+            V3TaskCreateRequest {
+                title: "Valid V3 task".to_owned(),
+                intent: "Remain visible after quarantine".to_owned(),
+                acceptance_criteria: vec!["Views remain usable".to_owned()],
+            },
+        )
+        .unwrap();
+        let legacy = project.join(".vibehub/tasks/T-20260718191720-ffb8c89a");
+        fs::create_dir(&legacy).unwrap();
+        let legacy_yaml = "schema_version: 1\nkind: vibehub_task\ntask_id: T-20260718191720-ffb8c89a\ntitle: Legacy task\nmode: evidence_drive\nphase: align\nphase_status: active\n";
+        fs::write(legacy.join("task.yaml"), legacy_yaml).unwrap();
+        fs::write(legacy.join("artifact.md"), "preserve me").unwrap();
+
+        let result = quarantine_v3_task(&project, "T-20260718191720-ffb8c89a").unwrap();
+        assert_eq!(result.status, "quarantined");
+        assert!(!legacy.exists());
+        assert_eq!(
+            fs::read_to_string(project.join(&result.archive_path).join("task.yaml")).unwrap(),
+            legacy_yaml
+        );
+        assert_eq!(
+            fs::read_to_string(project.join(&result.archive_path).join("artifact.md")).unwrap(),
+            "preserve me"
+        );
+        let audit: Value =
+            serde_json::from_str(&fs::read_to_string(project.join(&result.audit_path)).unwrap())
+                .unwrap();
+        assert_eq!(audit["task_id"], "T-20260718191720-ffb8c89a");
+        assert_eq!(audit["action"], "quarantined");
+        assert_eq!(
+            V3ViewRepository::open(&project)
+                .unwrap()
+                .load_bundle(&valid.task_id)
+                .unwrap()
+                .project_overview["active_tasks"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        fs::remove_dir_all(project).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_quarantine_valid_v3_task_metadata() {
+        let project = temp_project();
+        initialize_v3(&project).unwrap();
+        let valid = create_v3_task(
+            &project,
+            V3TaskCreateRequest {
+                title: "Valid V3 task".to_owned(),
+                intent: "Must not be moved".to_owned(),
+                acceptance_criteria: vec!["Safety".to_owned()],
+            },
+        )
+        .unwrap();
+        let error = quarantine_v3_task(&project, &valid.task_id).unwrap_err();
+        assert_eq!(error.code, "V3_TASK_QUARANTINE_REQUIRES_INVALID_METADATA");
+        assert!(project.join(&valid.task_path).exists());
+        fs::remove_dir_all(project).unwrap();
+    }
+}

--- a/crates/vibehub-core/src/v3/views.rs
+++ b/crates/vibehub-core/src/v3/views.rs
@@ -63,6 +63,12 @@ struct TaskDocument {
     dependencies: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+struct TaskReadResult {
+    tasks: Vec<TaskDocument>,
+    warnings: Vec<Value>,
+}
+
 impl V3ViewRepository {
     pub fn open(root: impl AsRef<Path>) -> Result<Self, V3Error> {
         let store = V3EventStore::open(&root)?;
@@ -75,7 +81,7 @@ impl V3ViewRepository {
 
     pub fn current_task_id(&self) -> Result<String, V3Error> {
         let pointer_path = self.root.join(".vibehub/tasks/current");
-        if pointer_path.is_dir() {
+        let pointed_task_id = if pointer_path.is_dir() {
             let content = fs::read_to_string(pointer_path.join("task.yaml"))
                 .map_err(internal("V3_CURRENT_TASK_READ_FAILED"))?;
             let task: TaskDocument = serde_yaml::from_str(&content).map_err(|error| {
@@ -86,25 +92,43 @@ impl V3ViewRepository {
                     error.to_string(),
                 )
             })?;
-            return self.effective_current_task_id(task.task_id);
+            Ok(task.task_id)
+        } else {
+            resolve_current_task(&self.root)
+                .map(|pointer| pointer.task_id)
+                .map_err(|error| {
+                    V3Error::new(
+                        "V3_CURRENT_TASK_INVALID",
+                        V3ErrorCategory::CorruptLog,
+                        false,
+                        error.to_string(),
+                    )
+                })
+        };
+        match pointed_task_id.and_then(|task_id| self.effective_current_task_id(task_id)) {
+            Ok(task_id) => Ok(task_id),
+            Err(error) if current_task_fallback_allowed(&error) => {
+                self.fallback_current_task_id().or(Err(error))
+            }
+            Err(error) => Err(error),
         }
-
-        let pointed_task_id = resolve_current_task(&self.root)
-            .map(|pointer| pointer.task_id)
-            .map_err(|error| {
-                V3Error::new(
-                    "V3_CURRENT_TASK_INVALID",
-                    V3ErrorCategory::CorruptLog,
-                    false,
-                    error.to_string(),
-                )
-            })?;
-        self.effective_current_task_id(pointed_task_id)
     }
 
     fn effective_current_task_id(&self, pointed_task_id: String) -> Result<String, V3Error> {
         let events = self.store.load_project(&self.project_id())?;
-        let pointed_task = self.read_task(&pointed_task_id)?;
+        let tasks = self.read_tasks()?.tasks;
+        let Some(pointed_task) = tasks.iter().find(|task| task.task_id == pointed_task_id) else {
+            return self
+                .select_fallback_task_id(&tasks, &events)
+                .ok_or_else(|| {
+                    V3Error::new(
+                        "V3_CURRENT_TASK_INVALID",
+                        V3ErrorCategory::CorruptLog,
+                        false,
+                        "current task is missing or has invalid V3 metadata",
+                    )
+                });
+        };
         let pointed_lifecycle = fold_task(&pointed_task_id, &events);
         let pointed_has_lifecycle = events
             .iter()
@@ -118,21 +142,46 @@ impl V3ViewRepository {
             return Ok(pointed_task_id);
         }
 
-        for task in self.read_tasks()? {
-            let lifecycle = fold_task(&task.task_id, &events);
-            let has_lifecycle = events
-                .iter()
-                .any(|event| event.aggregate_id == task.task_id);
-            let state = if has_lifecycle {
-                projected_task_state(&lifecycle)
-            } else {
-                task_state(&task)
-            };
-            if !is_terminal_task_state(state) {
-                return Ok(task.task_id);
-            }
-        }
-        Ok(pointed_task_id)
+        Ok(self
+            .select_fallback_task_id(&tasks, &events)
+            .unwrap_or(pointed_task_id))
+    }
+
+    fn fallback_current_task_id(&self) -> Result<String, V3Error> {
+        let events = self.store.load_project(&self.project_id())?;
+        let tasks = self.read_tasks()?.tasks;
+        self.select_fallback_task_id(&tasks, &events)
+            .ok_or_else(|| {
+                V3Error::new(
+                    "V3_CURRENT_TASK_INVALID",
+                    V3ErrorCategory::CorruptLog,
+                    false,
+                    "current task is invalid and no valid V3 task is available",
+                )
+            })
+    }
+
+    fn select_fallback_task_id(
+        &self,
+        tasks: &[TaskDocument],
+        events: &[V3EventEnvelope],
+    ) -> Option<String> {
+        tasks
+            .iter()
+            .find(|task| {
+                let lifecycle = fold_task(&task.task_id, events);
+                let has_lifecycle = events
+                    .iter()
+                    .any(|event| event.aggregate_id == task.task_id);
+                let state = if has_lifecycle {
+                    projected_task_state(&lifecycle)
+                } else {
+                    task_state(task)
+                };
+                !is_terminal_task_state(state)
+            })
+            .or_else(|| tasks.first())
+            .map(|task| task.task_id.clone())
     }
 
     pub fn project_id(&self) -> String {
@@ -173,7 +222,9 @@ impl V3ViewRepository {
         } else {
             task_state(&task)
         };
-        let project_tasks = self.read_tasks()?;
+        let task_read = self.read_tasks()?;
+        let task_metadata_warnings = task_read.warnings;
+        let project_tasks = task_read.tasks;
         let active_tasks: Vec<Value> = project_tasks
             .iter()
             .filter_map(|project_task| {
@@ -283,6 +334,8 @@ impl V3ViewRepository {
             .as_array()
             .cloned()
             .unwrap_or_default();
+        let mut overview_warnings = task_metadata_warnings.clone();
+        overview_warnings.extend(architecture_warnings.clone());
         let index_state = project_structure["index_state"].as_str().unwrap_or("error");
         let model_state = match index_state {
             "ready" => "ready",
@@ -296,6 +349,11 @@ impl V3ViewRepository {
         let structure_completeness = project_structure["completeness"]
             .as_str()
             .unwrap_or("unknown");
+        let overview_completeness = if task_metadata_warnings.is_empty() {
+            structure_completeness
+        } else {
+            "partial"
+        };
         let structure_model_version = project_structure["model_version"]
             .as_str()
             .unwrap_or(MODEL_VERSION);
@@ -303,7 +361,7 @@ impl V3ViewRepository {
         let project_overview = json!({
             "schema_version": "1.0", "project_id": project_id, "name": self.root.file_name().and_then(|v| v.to_str()).unwrap_or("Project"),
             "root": native_root, "generated_at": generated_at, "model_version": MODEL_VERSION,
-            "freshness": structure_freshness, "completeness": structure_completeness,
+            "freshness": structure_freshness, "completeness": overview_completeness,
             "repository": {"state": if self.root.join(".git").exists() {"available"} else {"not_repository"}, "branch": Value::Null, "head": Value::Null, "dirty": Value::Null, "worktree_count": 1},
             "model": {"state": model_state, "last_evidence_at": generated_at, "generator_version": structure_model_version, "indexed_files": indexed_files},
             "architecture": {"declared_docs": declared_docs, "modules": architecture_modules, "relationships": architecture_edges.len(), "confidence": architecture_confidence, "evidence_refs": architecture_evidence_refs},
@@ -311,7 +369,7 @@ impl V3ViewRepository {
             "active_tasks": active_tasks,
             "archived_tasks": archived_tasks,
             "protocol_coverage": {"state": protocol_coverage(opened_sessions, closed_sessions, explicit_session_gaps), "opened_sessions": opened_sessions, "closed_sessions": closed_sessions, "gaps": explicit_session_gaps},
-            "evidence_refs": evidence_refs, "warnings": architecture_warnings, "errors": architecture_errors
+            "evidence_refs": evidence_refs, "warnings": overview_warnings, "errors": architecture_errors
         });
         let agent_results =
             agent_results_view(&project_id, task_id, &generated_at, &events, &evidence_refs);
@@ -338,7 +396,7 @@ impl V3ViewRepository {
             "schema_version": "1.0", "project_id": project_id, "task_id": task.task_id, "title": task.title, "state": current_task_state,
             "generated_at": generated_at, "model_version": MODEL_VERSION, "freshness": "fresh", "completeness": "complete",
             "criteria": current_criteria, "blocker_details": current_blocker_details.clone(), "completion": completion_view(&lifecycle), "lanes": lanes, "events": timeline_events, "window": page(events.len()),
-            "evidence_refs": evidence_refs, "warnings": [], "errors": []
+            "evidence_refs": evidence_refs, "warnings": task_metadata_warnings.clone(), "errors": []
         });
 
         let graph_nodes: Vec<Value> = lifecycle.nodes.values().map(|node| {
@@ -373,17 +431,16 @@ impl V3ViewRepository {
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_owned();
-        let plan_warnings = if lifecycle.nodes.is_empty() {
-            vec![json!({
+        let mut plan_warnings = task_metadata_warnings.clone();
+        if lifecycle.nodes.is_empty() {
+            plan_warnings.push(json!({
                 "code": "V3_PLAN_NOT_RECORDED",
                 "severity": "warning",
                 "message_key": "v3.warning.plan_not_recorded",
                 "details": {},
                 "evidence_refs": evidence_refs
-            })]
-        } else {
-            Vec::new()
-        };
+            }));
+        }
         let planned_worktrees = orchestration.worktrees.len();
         let observed_worktrees = orchestration
             .worktrees
@@ -399,6 +456,8 @@ impl V3ViewRepository {
             "evidence_refs": evidence_refs, "warnings": plan_warnings, "errors": []
         });
 
+        let mut node_warnings = task_metadata_warnings;
+        node_warnings.extend(architecture_warnings.clone());
         let node_brief = json!({
             "schema_version": "1.0", "project_id": project_id, "task_id": task.task_id, "node_id": node_id,
             "generated_at": generated_at, "model_version": MODEL_VERSION, "freshness": structure_freshness, "completeness": structure_completeness,
@@ -411,7 +470,7 @@ impl V3ViewRepository {
             "blocker_details": current_blocker_details,
             "budget": {"max_tokens": 8000, "estimated_tokens": 1000, "truncated_sections": []},
             "source_versions": {"view_model": MODEL_VERSION, "project_model": structure_model_version}, "protocol_coverage": protocol_coverage(opened_sessions, closed_sessions, explicit_session_gaps),
-            "evidence_refs": evidence_refs, "warnings": architecture_warnings, "errors": architecture_errors
+            "evidence_refs": evidence_refs, "warnings": node_warnings, "errors": architecture_errors
         });
 
         Ok(V3ViewBundle {
@@ -524,18 +583,20 @@ impl V3ViewRepository {
             .join(".vibehub/tasks")
             .join(task_id)
             .join("task.yaml");
-        let content = fs::read_to_string(path).map_err(internal("V3_TASK_NOT_FOUND"))?;
-        serde_yaml::from_str(&content).map_err(|error| {
+        let content = fs::read_to_string(&path).map_err(internal("V3_TASK_NOT_FOUND"))?;
+        let task = serde_yaml::from_str(&content).map_err(|error| {
             V3Error::new(
                 "V3_TASK_INVALID",
                 V3ErrorCategory::CorruptLog,
                 false,
-                error.to_string(),
+                format!("{}: {error}", path.display()),
             )
-        })
+        })?;
+        validate_task_identity(&task, task_id, &path)?;
+        Ok(task)
     }
 
-    fn read_tasks(&self) -> Result<Vec<TaskDocument>, V3Error> {
+    fn read_tasks(&self) -> Result<TaskReadResult, V3Error> {
         let tasks_root = self.root.join(".vibehub/tasks");
         let mut task_paths = fs::read_dir(&tasks_root)
             .map_err(internal("V3_TASKS_READ_FAILED"))?
@@ -550,20 +611,111 @@ impl V3ViewRepository {
             })
             .collect::<Vec<_>>();
         task_paths.sort();
-        task_paths
-            .into_iter()
-            .map(|path| {
-                let content = fs::read_to_string(&path).map_err(internal("V3_TASK_READ_FAILED"))?;
-                serde_yaml::from_str(&content).map_err(|error| {
-                    V3Error::new(
-                        "V3_TASK_INVALID",
-                        V3ErrorCategory::CorruptLog,
-                        false,
-                        format!("{}: {error}", path.display()),
-                    )
-                })
-            })
-            .collect()
+        let mut tasks = Vec::new();
+        let mut warnings = Vec::new();
+        for path in task_paths {
+            let expected_task_id = path
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            match self.read_task_document(&path, expected_task_id) {
+                Ok(task) => tasks.push(task),
+                Err(error) => warnings.push(task_metadata_warning(&self.root, &path, &error)),
+            }
+        }
+        Ok(TaskReadResult { tasks, warnings })
+    }
+
+    fn read_task_document(
+        &self,
+        path: &Path,
+        expected_task_id: &str,
+    ) -> Result<TaskDocument, V3Error> {
+        let content = fs::read_to_string(path).map_err(internal("V3_TASK_READ_FAILED"))?;
+        let task = serde_yaml::from_str(&content).map_err(|error| {
+            V3Error::new(
+                "V3_TASK_INVALID",
+                V3ErrorCategory::CorruptLog,
+                false,
+                format!("{}: {error}", path.display()),
+            )
+        })?;
+        validate_task_identity(&task, expected_task_id, path)?;
+        Ok(task)
+    }
+}
+
+fn current_task_fallback_allowed(error: &V3Error) -> bool {
+    matches!(
+        error.code.as_str(),
+        "V3_CURRENT_TASK_INVALID"
+            | "V3_CURRENT_TASK_READ_FAILED"
+            | "V3_TASK_INVALID"
+            | "V3_TASK_NOT_FOUND"
+            | "V3_TASK_READ_FAILED"
+    )
+}
+
+fn validate_task_identity(
+    task: &TaskDocument,
+    expected_task_id: &str,
+    path: &Path,
+) -> Result<(), V3Error> {
+    if task.task_id != expected_task_id {
+        return Err(V3Error::new(
+            "V3_TASK_INVALID",
+            V3ErrorCategory::CorruptLog,
+            false,
+            format!(
+                "{}: task_id '{}' does not match task directory '{}'",
+                path.display(),
+                task.task_id,
+                expected_task_id
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn task_metadata_warning(root: &Path, path: &Path, error: &V3Error) -> Value {
+    let task_id = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown-task");
+    let task_path = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    json!({
+        "code": "V3_TASK_METADATA_INVALID",
+        "severity": "warning",
+        "message_key": "v3.warning.task_metadata_invalid",
+        "details": {
+            "task_id": task_id,
+            "task_path": task_path,
+            "reason_code": error.code,
+            "reason": limited_metadata_error(&error.message),
+            "recommended_action": "Review and preserve the task, then run `vibehub v3 <project> quarantine-task <task_id>`."
+        },
+        "evidence_refs": [{
+            "evidence_id": format!("task-metadata:{task_id}"),
+            "kind": "file",
+            "grade": "hard_observed",
+            "label_key": "v3.evidence.task_metadata",
+            "locator": format!("file:{task_path}")
+        }]
+    })
+}
+
+fn limited_metadata_error(message: &str) -> String {
+    const MAX_CHARS: usize = 512;
+    if message.chars().count() <= MAX_CHARS {
+        message.to_owned()
+    } else {
+        format!("{}…", message.chars().take(MAX_CHARS).collect::<String>())
     }
 }
 
@@ -2699,6 +2851,70 @@ mod tests {
         assert_eq!(bundle.task_timeline["events"].as_array().unwrap().len(), 1);
         assert_eq!(bundle.task_timeline["completion"]["valid"], false);
         assert_eq!(bundle.task_timeline["completion"]["confirmed"], false);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn malformed_task_metadata_does_not_block_valid_v3_task_views() {
+        let root =
+            std::env::temp_dir().join(format!("vibehub-v3-malformed-task-{}", Uuid::new_v4()));
+        fs::create_dir(&root).unwrap();
+        super::super::initialize_v3(&root).unwrap();
+        let valid = create_v3_task(
+            &root,
+            V3TaskCreateRequest {
+                title: "Valid task".to_owned(),
+                intent: "Keep valid V3 tasks visible".to_owned(),
+                acceptance_criteria: vec!["View bundle remains available".to_owned()],
+            },
+        )
+        .unwrap();
+        let legacy_task_id = "T-20260718191720-ffb8c89a";
+        let legacy_dir = root.join(".vibehub/tasks").join(legacy_task_id);
+        fs::create_dir(&legacy_dir).unwrap();
+        fs::write(
+            legacy_dir.join("task.yaml"),
+            format!(
+                "schema_version: 1\\nkind: vibehub_task\\ntask_id: {legacy_task_id}\\ntitle: Legacy task\\nmode: evidence_drive\\nphase: align\\nphase_status: active\\n"
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join(".vibehub/tasks/current"),
+            format!(
+                "schema_version: 1\\nkind: current_task_pointer\\ntask_id: {legacy_task_id}\\npath: .vibehub/tasks/{legacy_task_id}\\nupdated_at: 2026-07-18T00:00:00Z\\nupdated_by: vibehub\\n"
+            ),
+        )
+        .unwrap();
+
+        let repository = V3ViewRepository::open(&root).unwrap();
+        let bundle = repository.load_bundle(&valid.task_id).unwrap();
+
+        assert_eq!(repository.current_task_id().unwrap(), valid.task_id);
+        assert_eq!(
+            bundle.project_overview["active_tasks"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        let warning = bundle.project_overview["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|warning| warning["code"] == "V3_TASK_METADATA_INVALID")
+            .expect("invalid legacy task warning");
+        assert_eq!(warning["details"]["task_id"], legacy_task_id);
+        assert!(warning["details"]["recommended_action"]
+            .as_str()
+            .unwrap()
+            .contains("quarantine-task"));
+        assert!(bundle.task_timeline["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|warning| warning["code"] == "V3_TASK_METADATA_INVALID"));
+
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/vibehub-core/src/vibehub/start_task.rs
+++ b/crates/vibehub-core/src/vibehub/start_task.rs
@@ -121,6 +121,7 @@ pub fn start_task(
     phase: Option<String>,
 ) -> Result<VibehubStartTaskResult> {
     let project_root = canonical_project_root(project_root.as_ref())?;
+    reject_v3_legacy_task_creation(&project_root)?;
     ensure_initialized(&project_root)?;
 
     let _ = research::archive_current_research(&project_root);
@@ -256,6 +257,7 @@ pub fn start_task_intake(
     request: VibehubStartTaskIntakeRequest,
 ) -> Result<VibehubStartTaskIntakeResult> {
     let project_root = canonical_project_root(project_root.as_ref())?;
+    reject_v3_legacy_task_creation(&project_root)?;
     ensure_initialized(&project_root)?;
 
     let mut drafts = normalize_task_drafts(&request)?;
@@ -889,6 +891,17 @@ fn ensure_initialized(project_root: &Path) -> Result<()> {
     Ok(())
 }
 
+fn reject_v3_legacy_task_creation(project_root: &Path) -> Result<()> {
+    let layout = crate::v3::inspect_project_layout(project_root)
+        .map_err(|error| anyhow!("V3_PROJECT_LAYOUT_INSPECTION_FAILED: {error}"))?;
+    if layout.state == crate::v3::ProjectLayoutState::V3 {
+        return Err(anyhow!(
+            "V3_LEGACY_START_UNSUPPORTED: this project uses schema_version: 3; legacy `vibehub start` cannot create V3 task metadata. Use `vibehub v3 <project> task-create <request_json_path|--stdin|->`."
+        ));
+    }
+    Ok(())
+}
+
 pub fn default_phase_for_mode(mode: &str) -> &'static str {
     match mode {
         "yolo_drive" => "align_lite",
@@ -1322,6 +1335,31 @@ mod tests {
         assert_eq!(handoff.task_id, started.task_id);
         assert_eq!(handoff.run_id, started.run_id);
         assert!(handoff.complete);
+
+        fs::remove_dir_all(project).expect("cleanup");
+    }
+
+    #[test]
+    fn v3_projects_reject_legacy_start_before_writing_legacy_task_metadata() {
+        let project = temp_project();
+        crate::v3::initialize_v3(&project).expect("initialize v3");
+
+        let error = start_task(
+            &project,
+            Some("Must not become a legacy task".to_owned()),
+            Some("evidence_drive".to_owned()),
+            None,
+        )
+        .expect_err("legacy start must be rejected in a V3 project");
+
+        assert!(error.to_string().contains("V3_LEGACY_START_UNSUPPORTED"));
+        assert!(error
+            .to_string()
+            .contains("vibehub v3 <project> task-create"));
+        assert!(
+            !project.join(".vibehub/tasks").exists(),
+            "the rejection must happen before any legacy task path is created"
+        );
 
         fs::remove_dir_all(project).expect("cleanup");
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vibehub",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vibehub",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vibehub",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "A cross-platform launcher for development tools",
     "license": "Apache-2.0",
     "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibehub"
-version = "3.0.2"
+version = "3.0.3"
 description = "A cross-platform launcher for development tools"
 authors = ["VibeHub"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema":  "https://schema.tauri.app/config/2.0",
     "productName":  "VibeHub",
-    "version":  "3.0.2",
+    "version":  "3.0.3",
     "identifier":  "com.vibehub.launcher",
     "build":  {
                   "beforeDevCommand":  "npm run dev",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -784,6 +784,7 @@
             "messages": {
                 "architectureIndexPending": "The architecture index is still pending; structure information may be incomplete.",
                 "planNotRecorded": "The implementation plan has not been recorded; the execution path may be incomplete.",
+                "taskMetadataInvalid": "A task has invalid V3 metadata and was excluded so valid tasks remain available.",
                 "agentResultSessionClosed": "The Agent session is closed; the leftover result is shown as pending.",
                 "agentResultStatusInvalid": "The Agent result has an invalid status and is shown as failed.",
                 "agentResultDetailsNormalized": "A historical Agent result did not match the current contract and was normalized for safe display.",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -784,6 +784,7 @@
             "messages": {
                 "architectureIndexPending": "架構索引尚未完成，結構資訊可能暫時不完整。",
                 "planNotRecorded": "尚未記錄實作計畫，目前任務的執行路徑可能不完整。",
+                "taskMetadataInvalid": "存在不合法的 V3 任務中繼資料，已將其排除，其他合法任務仍可繼續使用。",
                 "agentResultSessionClosed": "Agent 工作階段已關閉，遺留結果已按待處理狀態顯示。",
                 "agentResultStatusInvalid": "Agent 結果狀態無效，已按失敗狀態顯示。",
                 "agentResultDetailsNormalized": "歷史 Agent 結果不符合目前契約，已安全正規化後顯示。",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -784,6 +784,7 @@
             "messages": {
                 "architectureIndexPending": "架构索引尚未完成，结构信息可能暂不完整。",
                 "planNotRecorded": "尚未记录实现计划，当前任务的执行路径可能不完整。",
+                "taskMetadataInvalid": "存在不合法的 V3 任务元数据，已将其排除，其他合法任务仍可继续使用。",
                 "agentResultSessionClosed": "Agent 会话已关闭，遗留结果已按待处理状态显示。",
                 "agentResultStatusInvalid": "Agent 结果状态无效，已按失败状态显示。",
                 "agentResultDetailsNormalized": "历史 Agent 结果不符合当前契约，已安全归一化后显示。",

--- a/src/v3/components/common/diagnosticLabels.ts
+++ b/src/v3/components/common/diagnosticLabels.ts
@@ -5,6 +5,7 @@ export type Diagnostic = Warning | StructuredError;
 const diagnosticTranslationKeys: Record<string, string> = {
   "v3.warning.architecture_index_pending": "v3.diagnostics.messages.architectureIndexPending",
   "v3.warning.plan_not_recorded": "v3.diagnostics.messages.planNotRecorded",
+  "v3.warning.task_metadata_invalid": "v3.diagnostics.messages.taskMetadataInvalid",
   "v3.warning.agent_result_session_closed": "v3.diagnostics.messages.agentResultSessionClosed",
   "v3.warning.agent_result_status_invalid": "v3.diagnostics.messages.agentResultStatusInvalid",
   "v3.warning.agent_result_details_normalized": "v3.diagnostics.messages.agentResultDetailsNormalized",


### PR DESCRIPTION
Summary: reject legacy start commands in V3 projects before old task metadata is written; retain valid V3 task views with structured malformed-metadata warnings; add atomic quarantine-task preservation and audit flow; release version 3.0.3. Validation: release checks, V3 contracts, MCP, production frontend build, Rust formatting and locked workspace tests, CLI build, and macOS App bundle strict ad-hoc codesign verification all passed.