### PR TITLE
fix(release): restore Homebrew cask chaining

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -8,6 +8,17 @@ on:
       tag:
         description: 'Published release tag to package, for example v2.0.0'
         required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Published release tag to package, for example v2.0.0'
+        required: true
+        type: string
+      require_tap_update:
+        description: 'Fail instead of skipping when the tap write token is unavailable'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -23,6 +34,7 @@ jobs:
       TAP_REPO: ChenM0M/homebrew-vibehub
       CASK_TOKEN: vibehub
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      REQUIRE_TAP_UPDATE: ${{ inputs.require_tap_update || false }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
@@ -32,6 +44,10 @@ jobs:
         run: |
           if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
+            if [ "$REQUIRE_TAP_UPDATE" = "true" ]; then
+              echo "::error::HOMEBREW_TAP_TOKEN is required for the release-triggered cask update."
+              exit 1
+            fi
           else
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,3 +388,11 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --draft=false \
             --latest="${{ !contains(env.RELEASE_TAG, '-') }}"
+
+  update-homebrew-cask:
+    needs: publish-release
+    uses: ./.github/workflows/homebrew.yml
+    with:
+      tag: ${{ inputs.tag || github.ref_name }}
+      require_tap_update: true
+    secrets: inherit

--- a/docs/v3/agent-release-process.md
+++ b/docs/v3/agent-release-process.md
@@ -87,8 +87,9 @@ artifact/hash 都不能冒充当前版本证据。
   MCP 和 Tauri 构建门槛。
 - `Release` 先 checkout 精确 tag，运行 preflight，再创建一个 draft Release，
   上传 macOS、Windows、Linux 产物和平台 SHA-256 清单。只有全部 matrix job
-  成功且必需产物校验通过后，最终 job 才能把 draft 发布；发布事件随后触发
-  Homebrew cask 更新。任何平台失败时必须保留 draft，不得发布残缺版本。
+  成功且必需产物校验通过后，最终 job 才能把 draft 发布；随后直接调用可复用的
+  Homebrew cask workflow，避免由 `GITHUB_TOKEN` 发布事件无法触发下游 workflow。
+  任何平台失败时必须保留 draft，不得发布残缺版本。
 - Apple Developer ID/notarization 与 Windows Authenticode 凭据是可选增强；凭据
   完整时流水线启用正式签名，缺少时继续生成经过完整测试和 SHA-256 校验的
   macOS ad-hoc / Windows unsigned 产物。不得把 fallback 产物称为正式签名。
@@ -102,9 +103,10 @@ artifact/hash 都不能冒充当前版本证据。
 - Windows：`WINDOWS_CERTIFICATE`、`WINDOWS_CERTIFICATE_PASSWORD`；
 - 可选 Homebrew：`HOMEBREW_TAP_TOKEN`。
 
-`HOMEBREW_TAP_TOKEN` 缺少时，Homebrew workflow 跳过跨仓库写入；发布 Agent
-必须使用正式 Release 的双架构 DMG 与真实 SHA-256，通过已授权的 SSH 工作流
-更新 `ChenM0M/homebrew-vibehub`。
+独立触发 Homebrew workflow 时，`HOMEBREW_TAP_TOKEN` 缺少会跳过跨仓库写入；
+Release 通过 reusable workflow 调用时则会明确失败，避免 cask 静默滞后。若 token
+不可用，发布 Agent 必须使用正式 Release 的双架构 DMG 与真实 SHA-256，通过已授权
+的 SSH 工作流更新 `ChenM0M/homebrew-vibehub`。
 
 ## 5. Windows 发布后手测交接
 

--- a/docs/v3/release-guide.md
+++ b/docs/v3/release-guide.md
@@ -27,8 +27,8 @@ layout states and error codes.
 The `3.0.0` GitHub Actions workflow validates version equality and the complete
 test gate, then creates one draft Release containing macOS, Windows, and Linux
 assets plus per-platform SHA-256 manifests. The workflow publishes that draft
-only after every platform job succeeds and all required manifests are present;
-the published event then triggers the Homebrew cask update. Final artifact
+only after every platform job succeeds and all required manifests are present,
+then directly calls the reusable Homebrew cask workflow. Final artifact
 filenames and hashes do not exist until that tagged workflow succeeds; never
 copy historical hashes into a `3.0.0` release record.
 

--- a/scripts/release/preflight.mjs
+++ b/scripts/release/preflight.mjs
@@ -11,6 +11,8 @@ const tauriWindowsConfig = await readJson("src-tauri/tauri.windows.conf.json");
 const coreCargo = await readText("crates/vibehub-core/Cargo.toml");
 const cliCargo = await readText("crates/vibehub-cli/Cargo.toml");
 const tauriCargo = await readText("src-tauri/Cargo.toml");
+const releaseWorkflow = await readText(".github/workflows/release.yml");
+const homebrewWorkflow = await readText(".github/workflows/homebrew.yml");
 
 const cargoVersion = (content, label) => {
   const match = content.match(/^version\s*=\s*"([^"]+)"/m);
@@ -58,6 +60,28 @@ const sharedWindowFields = [
 for (const field of sharedWindowFields) {
   if (windowsWindow[field] !== baseWindow[field]) {
     throw new Error(`Windows Tauri window ${field} must match the base window configuration`);
+  }
+}
+
+const requiredReleaseWorkflowFragments = [
+  "uses: ./.github/workflows/homebrew.yml",
+  "require_tap_update: true",
+  "secrets: inherit",
+];
+for (const fragment of requiredReleaseWorkflowFragments) {
+  if (!releaseWorkflow.includes(fragment)) {
+    throw new Error(`release workflow must retain the Homebrew recovery contract: ${fragment}`);
+  }
+}
+
+const requiredHomebrewWorkflowFragments = [
+  "workflow_call:",
+  "require_tap_update:",
+  "HOMEBREW_TAP_TOKEN is required for the release-triggered cask update.",
+];
+for (const fragment of requiredHomebrewWorkflowFragments) {
+  if (!homebrewWorkflow.includes(fragment)) {
+    throw new Error(`Homebrew workflow must retain the reusable release contract: ${fragment}`);
   }
 }
 


### PR DESCRIPTION
补跑并验证 v3.0.3 Homebrew cask 更新；将 Homebrew workflow 改为可复用 workflow，Release 发布成功后直接调用它，避免 GITHUB_TOKEN 触发的 release:published 事件被抑制。缺失 HOMEBREW_TAP_TOKEN 时，release 调用会明确失败。